### PR TITLE
Modified the query in the Project.class.inc so that the scanner candidate does not show up as a candidate in the API

### DIFF
--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -273,7 +273,7 @@ class Project
             FROM
               candidate
             WHERE
-              active = 'Y' AND
+              active = 'Y' AND Entity_type='Human' AND
               FIND_IN_SET(IFNULL(projectId, '-1'), :v_project_id)
             ",
             array('v_project_id' => implode(',', $p))


### PR DESCRIPTION
Since the scanner candidate has no data attached to it yet, it should not be in the list of subjects available in the API. This query fix removes the scanner candidate from the list of available candidate.